### PR TITLE
Fixing 'variable' snippet

### DIFF
--- a/UltiSnips/terraform.snippets
+++ b/UltiSnips/terraform.snippets
@@ -1,7 +1,7 @@
 # variable
 snippet var "variable"
 variable "${1:name}" {
-  ${1}
+  ${2}
 }
 endsnippet
 


### PR DESCRIPTION
The way it was working the variable always have the name 'name' and the
cursor always jumped straight to inside the curly braces.